### PR TITLE
Update Select.swift

### DIFF
--- a/Sources/Select.swift
+++ b/Sources/Select.swift
@@ -92,7 +92,7 @@ extension SQLiteStORM {
 			}
 			clauseSelectList = keys.joined(separator: ",")
 		}
-		if whereclause.characters.count > 0 {
+		if whereclause.count > 0 {
 			clauseWhere = " WHERE \(whereclause)"
 		}
 


### PR DESCRIPTION
'characters' is deprecated. The string is used directly.