### PR TITLE
Supporting optionals

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
 		.package(url: "https://github.com/PerfectlySoft/Perfect-Logger.git", from: "3.0.0"),
 	],
 	targets: [
-		.target(name: "SQLiteStORM", dependencies: ["StORM", "PerfectSQLite", "PerfectLogger"])
+		.target(name: "SQLiteStORM", dependencies: ["StORM", "PerfectSQLite", "PerfectLogger"]),
+        .testTarget(name: "SQLiteStORMTests", dependencies: ["SQLiteStORM"])
 	]
 )

--- a/Sources/SQLiteStORM/Insert.swift
+++ b/Sources/SQLiteStORM/Insert.swift
@@ -17,10 +17,10 @@ extension SQLiteStORM {
 	public func insert(_ data: [(String, Any)]) throws -> Any {
 
 		var keys = [String]()
-		var vals = [String]()
+		var vals = [Any]()
 		for i in data {
 			keys.append(i.0)
-			vals.append(String(describing: i.1))
+			vals.append(i.1)
 		}
 		do {
 			return try insert(cols: keys, params: vals)

--- a/Sources/SQLiteStORM/SQLiteStORM.swift
+++ b/Sources/SQLiteStORM/SQLiteStORM.swift
@@ -9,7 +9,7 @@
 import StORM
 import PerfectSQLite
 import PerfectLogger
-
+import Foundation
 
 /// SQLiteConnector sets the connection parameters for the SQLite3 database file access
 /// Usage:
@@ -268,13 +268,18 @@ open class SQLiteStORM: StORM {
 			var verbage = ""
 			if !key.hasPrefix("internal_") && !key.hasPrefix("_") {
 				verbage = "\(key) "
-				if child.value is Int {
+                if self.check(child.value, is: Int.self) ||
+                    self.check(child.value, is: Bool.self) {
 					verbage += "INTEGER"
-				} else if child.value is Double {
+				} else if self.check(child.value, is: Float.self) ||
+                    self.check(child.value, is: Double.self) {
 					verbage += "REAL"
-				} else if child.value is Double {
-					verbage += "REAL"
-				} else if child.value is UInt || child.value is UInt8 || child.value is UInt16 || child.value is UInt32 || child.value is UInt64 {
+				} else if self.check(child.value, is: UInt.self) ||
+                    self.check(child.value, is: UInt8.self)  ||
+                    self.check(child.value, is: UInt16.self) ||
+                    self.check(child.value, is: UInt32.self) ||
+                    self.check(child.value, is: UInt64.self) ||
+                    self.check(child.value, is: Data.self) {
 					verbage += "BLOB"
 				} else {
 					verbage += "TEXT"
@@ -297,6 +302,13 @@ open class SQLiteStORM: StORM {
 			throw StORMError.error("\(error)")
 		}
 	}
+    
+    func check<T>(_ value: Any, is type: T.Type) -> Bool {
+        guard !(value is T) else { return true }
+        
+        let mirror = Mirror.init(reflecting: value)
+        return mirror.displayStyle == .optional && mirror.subjectType is Optional<T>.Type
+    }
 }
 
 

--- a/Sources/SQLiteStORM/Select.swift
+++ b/Sources/SQLiteStORM/Select.swift
@@ -92,7 +92,7 @@ extension SQLiteStORM {
 			}
 			clauseSelectList = keys.joined(separator: ",")
 		}
-		if whereclause.characters.count > 0 {
+		if whereclause.count > 0 {
 			clauseWhere = " WHERE \(whereclause)"
 		}
 

--- a/Sources/SQLiteStORM/Update.swift
+++ b/Sources/SQLiteStORM/Update.swift
@@ -22,7 +22,16 @@ extension SQLiteStORM {
 		var paramsString = [String]()
 		var set = [String]()
 		for i in 0..<params.count {
-			paramsString.append(String(describing: params[i]))
+            let value = String(describing: params[i])
+            var paramValue: String
+            if value.contains(string: "Optional(") {
+                let start: String.Index = value.index(value.index(of: "(")!, offsetBy: 1)
+                let end: String.Index = value.lastIndex(of: ")")!
+                paramValue = String.init(value[start..<end])
+            } else {
+                paramValue = value
+            }
+            paramsString.append(paramValue)
 			set.append("\(cols[i]) = :\(i+1)")
 		}
 		paramsString.append(String(describing: idValue))
@@ -46,10 +55,10 @@ extension SQLiteStORM {
 	public func update(data: [(String, Any)], idName: String = "id", idValue: Any) throws -> Bool {
 
 		var keys = [String]()
-		var vals = [String]()
+		var vals = [Any]()
 		for i in 0..<data.count {
 			keys.append(data[i].0)
-			vals.append(String(describing: data[i].1))
+			vals.append(data[i].1)
 		}
 		do {
 			return try update(cols: keys, params: vals, idName: idName, idValue: idValue)

--- a/Sources/SQLiteStORM/parseRows.swift
+++ b/Sources/SQLiteStORM/parseRows.swift
@@ -19,6 +19,7 @@
 import StORM
 import PerfectSQLite
 import PerfectLib
+import PerfectCSQLite3
 
 /// Supplies the parseRows method extending the main class.
 extension SQLiteStORM {
@@ -37,13 +38,17 @@ extension SQLiteStORM {
 		let this = StORMRow()
 		for i in 0..<row.columnCount() {
 			switch row.columnType(position: i) {
-			case 1:
+			case SQLITE_INTEGER:
 				this.data[row.columnName(position: i)] = row.columnInt(position: i)
-			case 2:
+			case SQLITE_FLOAT:
 				this.data[row.columnName(position: i)] = row.columnDouble(position: i)
-			case 4:
-				this.data[row.columnName(position: i)] = row.columnBlob(position: i)
-			// ignoring null, 5
+			case SQLITE_TEXT:
+				this.data[row.columnName(position: i)] = String(row.columnText(position: i))
+            case SQLITE_BLOB:
+                this.data[row.columnName(position: i)] = row.columnBlob(position: i)
+            case SQLITE_NULL:
+                this.data[row.columnName(position: i)] = nil
+                
 			default: // 3, string
 				this.data[row.columnName(position: i)] = String(row.columnText(position: i))
 			}

--- a/Tests/SQLiteStORMTests/SQLiteStORMTests.swift
+++ b/Tests/SQLiteStORMTests/SQLiteStORMTests.swift
@@ -60,6 +60,27 @@ class SQLiteStORMTests: XCTestCase {
 		}
 
 	}
+    
+    /* =============================================================================================
+     Types
+     ============================================================================================= */
+    func testTypes() {
+        let instance = SQLiteStORM.init()
+        XCTAssert(instance.check(Int(0), is: Int.self))
+        XCTAssert(instance.check(Float(0), is: Float.self))
+        XCTAssert(instance.check(Double(0), is: Double.self))
+        XCTAssert(instance.check(Data.init(), is: Data.self))
+        
+        XCTAssert(instance.check(Optional<Int>.some(0) as Any, is: Int.self))
+        XCTAssert(instance.check(Optional<Float>.some(0) as Any, is: Float.self))
+        XCTAssert(instance.check(Optional<Double>.some(0) as Any, is: Double.self))
+        XCTAssert(instance.check(Optional<Data>.some(.init()) as Any, is: Data.self))
+        
+        XCTAssert(instance.check(Optional<Int>.none as Any, is: Int.self))
+        XCTAssert(instance.check(Optional<Float>.none as Any, is: Float.self))
+        XCTAssert(instance.check(Optional<Double>.none as Any, is: Double.self))
+        XCTAssert(instance.check(Optional<Data>.none as Any, is: Data.self))
+    }
 
 	/* =============================================================================================
 	Save - New
@@ -331,6 +352,7 @@ class SQLiteStORMTests: XCTestCase {
 
 	static var allTests : [(String, (SQLiteStORMTests) -> () throws -> Void)] {
 		return [
+            ("testTypes", testTypes),
 			("testSaveNew", testSaveNew),
 			("testSaveUpdate", testSaveUpdate),
 			("testSaveCreate", testSaveCreate),

--- a/Tests/SQLiteStORMTests/SQLiteStORMTests.swift
+++ b/Tests/SQLiteStORMTests/SQLiteStORMTests.swift
@@ -10,6 +10,9 @@ class User: SQLiteStORM {
 	var firstname		: String = ""
 	var lastname		: String = ""
 	var email			: String = ""
+    var height          : Float = 0.0
+    var weight          : Double = 0.0
+    var age             : Int?
 
 
 	override open func table() -> String {
@@ -21,6 +24,9 @@ class User: SQLiteStORM {
 		firstname		= this.data["firstname"] as! String
 		lastname		= this.data["lastname"] as! String
 		email			= this.data["email"] as! String
+        height          = Float.init(this.data["height"] as! Double)
+        weight          = this.data["weight"] as! Double
+        age             = this.data["age"] as! Int?
 	}
 
 	func rows() -> [User] {
@@ -32,16 +38,6 @@ class User: SQLiteStORM {
 		}
 		return rows
 	}
-
-	// Create the table if needed
-//	public func setup() {
-//		do {
-//			try sqlExec("CREATE TABLE IF NOT EXISTS user (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, firstname TEXT, lastname TEXT, email TEXT)")
-//		} catch {
-//			print(error)
-//		}
-//	}
-
 }
 
 
@@ -50,6 +46,9 @@ class SQLiteStORMTests: XCTestCase {
 
 	override func setUp() {
 		super.setUp()
+        
+        try? FileManager.default.removeItem(atPath: "./testdb")
+        
 		SQLiteConnector.db = "./testdb"
 
 		obj = User()
@@ -90,6 +89,10 @@ class SQLiteStORMTests: XCTestCase {
 		//obj.connection = connect    // Use if object was instantiated without connection
 		obj.firstname = "X"
 		obj.lastname = "Y"
+        obj.email = "a@b.c"
+        obj.height = 1.85
+        obj.weight = 110.5
+        obj.age = nil
 
 		do {
 			try obj.save {id in obj.id = id as! Int }
@@ -107,19 +110,27 @@ class SQLiteStORMTests: XCTestCase {
 		//obj.connection = connect    // Use if object was instantiated without connection
 		obj.firstname = "X"
 		obj.lastname = "Y"
+        obj.email = "a@b.c"
+        obj.height = 1.85
+        obj.weight = 110.5
+        obj.age = nil
 
 		do {
 			try obj.save {id in obj.id = id as! Int }
 		} catch {
-			XCTFail(error as! String)
+			XCTFail(error.localizedDescription)
 		}
 
 		obj.firstname = "A"
 		obj.lastname = "B"
+        obj.email = "a@b.c"
+        obj.height = 1.85
+        obj.weight = 110.5
+        obj.age = nil
 		do {
 			try obj.save()
 		} catch {
-			XCTFail(error as! String)
+			XCTFail(error.localizedDescription)
 		}
 		print(obj.errorMsg)
 		XCTAssert(obj.id > 0, "Object not saved (update)")
@@ -151,11 +162,15 @@ class SQLiteStORMTests: XCTestCase {
 		//obj.connection = connect    // Use if object was instantiated without connection
 		obj.firstname = "X"
 		obj.lastname = "Y"
+        obj.email = "a@b.c"
+        obj.height = 1.85
+        obj.weight = 110.5
+        obj.age = nil
 
 		do {
 			try obj.save {id in obj.id = id as! Int }
 		} catch {
-			XCTFail(error as! String)
+			XCTFail(error.localizedDescription)
 		}
 
 		let obj2 = User()
@@ -163,7 +178,7 @@ class SQLiteStORMTests: XCTestCase {
 		do {
 			try obj2.get(obj.id)
 		} catch {
-			XCTFail(error as! String)
+			XCTFail(error.localizedDescription)
 		}
 		XCTAssert(obj.id == obj2.id, "Object not the same (id)")
 		XCTAssert(obj.firstname == obj2.firstname, "Object not the same (firstname)")
@@ -179,11 +194,15 @@ class SQLiteStORMTests: XCTestCase {
 		//obj.connection = connect    // Use if object was instantiated without connection
 		obj.firstname = "X"
 		obj.lastname = "Y"
+        obj.email = "a@b.c"
+        obj.height = 1.85
+        obj.weight = 110.5
+        obj.age = nil
 
 		do {
 			try obj.save {id in obj.id = id as! Int }
 		} catch {
-			XCTFail(error as! String)
+			XCTFail(error.localizedDescription)
 		}
 
 		let obj2 = User()
@@ -192,7 +211,7 @@ class SQLiteStORMTests: XCTestCase {
 		do {
 			try obj2.get()
 		} catch {
-			XCTFail(error as! String)
+			XCTFail(error.localizedDescription)
 		}
 		XCTAssert(obj.id == obj2.id, "Object not the same (id)")
 		XCTAssert(obj.firstname == obj2.firstname, "Object not the same (firstname)")
@@ -211,7 +230,7 @@ class SQLiteStORMTests: XCTestCase {
 			try obj.get(1111111)
 			XCTAssert(obj.results.cursorData.totalRecords == 0, "Object should have found no rows")
 		} catch {
-			XCTFail(error as! String)
+			XCTFail(error.localizedDescription)
 		}
 	}
 
@@ -230,7 +249,7 @@ class SQLiteStORMTests: XCTestCase {
 			try obj.get()
 			XCTAssert(obj.results.cursorData.totalRecords == 0, "Object should have found no rows")
 		} catch {
-			XCTFail(error as! String)
+			XCTFail(error.localizedDescription)
 		}
 	}
 
@@ -256,7 +275,7 @@ class SQLiteStORMTests: XCTestCase {
 		do {
 			try obj.save {id in obj.id = id as! Int }
 		} catch {
-			XCTFail(String(describing: error))
+			XCTFail(error.localizedDescription)
 		}
 
 		do {
@@ -277,7 +296,7 @@ class SQLiteStORMTests: XCTestCase {
 		do {
 			try obj.save {id in obj.id = id as! Int }
 		} catch {
-			XCTFail(String(describing: error))
+			XCTFail(error.localizedDescription)
 		}
 
 		let obj2 = User()
@@ -300,7 +319,7 @@ class SQLiteStORMTests: XCTestCase {
 		do {
 			try obj.save {id in obj.id = id as! Int }
 		} catch {
-			XCTFail(String(describing: error))
+			XCTFail(error.localizedDescription)
 		}
 
 		let obj2 = User()
@@ -346,8 +365,56 @@ class SQLiteStORMTests: XCTestCase {
 		}
 	}
 
-
-
+    /* =============================================================================================
+     New Types
+     ============================================================================================= */
+    func testNewTypes() {
+        let obj = User.init()
+        obj.firstname = "A"
+        obj.lastname = "B"
+        obj.email = "a@b.c"
+        obj.height = 1.85
+        obj.weight = 110.5
+        obj.age = nil
+        
+        do {
+            try obj.save(set: { obj.id = $0 as! Int })
+        } catch { XCTFail("Failed with error: \(error.localizedDescription)") }
+        
+        let obj2 = User.init()
+        do {
+            try obj2.select(whereclause: "id = :1", params: [obj.id], orderby: [])
+        } catch { XCTFail("Failed with error: \(error.localizedDescription)") }
+        
+        XCTAssert(obj2.rows().count > 0)
+        guard let result = obj2.rows().first else { return }
+        XCTAssert(result.id == obj.id)
+        XCTAssert(result.firstname == obj.firstname)
+        XCTAssert(result.lastname == obj.lastname)
+        XCTAssert(result.email == obj.email)
+        XCTAssert(result.height == obj.height)
+        XCTAssert(result.weight == obj.weight)
+        XCTAssert(result.age == nil)
+        
+        obj.age = 30
+        do {
+            try obj.save()
+        } catch { XCTFail("Failed with error: \(error.localizedDescription)") }
+        
+        do {
+            try obj2.select(whereclause: "id = :1", params: [obj.id], orderby: [])
+        } catch { XCTFail("Failed with error: \(error.localizedDescription)") }
+        
+        XCTAssert(obj2.rows().count > 0)
+        guard let result2 = obj2.rows().first else { return }
+        XCTAssert(result2.id == obj.id)
+        XCTAssert(result2.firstname == obj.firstname)
+        XCTAssert(result2.lastname == obj.lastname)
+        XCTAssert(result2.email == obj.email)
+        XCTAssert(result2.height == obj.height)
+        XCTAssert(result2.weight == obj.weight)
+        XCTAssert(result2.age == 30)
+    }
 
 
 	static var allTests : [(String, (SQLiteStORMTests) -> () throws -> Void)] {
@@ -365,6 +432,7 @@ class SQLiteStORMTests: XCTestCase {
 			("testDeleteID", testDeleteID),
 			("testFind", testFind),
 			("testSelect", testSelect),
+            ("testNewTypes", testNewTypes)
 		]
 	}
 


### PR DESCRIPTION
I've started the modifications needed to support new Types of values.
It is possible to have Float and Double properties to Table Entities now.
It is also possible to have a Optional wrapped value of any of the supported types.
The recovering of this values is still a problem, because depending on how you define your properties, you might still need to convert Float from Double that comes in the `StORMRow`'s data property.
Well, that's it in the pull request.

Another matter is that I've implemented a decoder using the Swift Builtin Decoder protocol.
It helps me because I don't need to extend the `open func to(_ this: StORMRow)` method.
The decoding fills the properties for me, helping a lot when I'm using your ORM.
I don't know if you may be interested in adopting this kind of techniques in your ORM's.
If yes, tell me that I'll be glad to share the code.

Best regards.